### PR TITLE
npm: adding npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+/src
+/coverage
+/node_modules
+.editorconfig
+.eslintrc.js
+.prettierignore
+.prettierrc
+jest.config.js
+rollup.config.js
+setupTests.ts
+tsconfig.json


### PR DESCRIPTION
Created `.npmignore` file to exclude unnecessary files when publishing to npm.